### PR TITLE
Fixing Mac Copy&Paster functionality

### DIFF
--- a/imgui4xp.xcodeproj/project.pbxproj
+++ b/imgui4xp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		25253C6C247FA1370061BFC2 /* imgui_demo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25253C2B247FA1370061BFC2 /* imgui_demo.cpp */; };
 		25253C6D247FA1370061BFC2 /* imgui_draw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25253C2C247FA1370061BFC2 /* imgui_draw.cpp */; };
 		25339A002485347500A65BE4 /* imgui_stdlib.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 253399F52485347500A65BE4 /* imgui_stdlib.cpp */; };
+		256CA1C7248C47BB009F4AAE /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 256CA1C6248C47BB009F4AAE /* ApplicationServices.framework */; };
 		25804FD524886B2B008961CB /* ImgWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25804FCD24886B2B008961CB /* ImgWindow.cpp */; };
 		25804FD824886B2B008961CB /* ImgFontAtlas.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25804FD224886B2B008961CB /* ImgFontAtlas.cpp */; };
 		D6A7BDAA16A1DEA200D1426A /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6A7BDA916A1DEA200D1426A /* OpenGL.framework */; };
@@ -43,6 +44,7 @@
 		255109CA248439ED002235C2 /* CMakeLists.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = CMakeLists.txt; path = src/CMakeLists.txt; sourceTree = "<group>"; };
 		255109CB248439ED002235C2 /* imgui_starter_window.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = imgui_starter_window.h; path = src/imgui_starter_window.h; sourceTree = "<group>"; };
 		255109CC248439ED002235C2 /* imgui4xp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = imgui4xp.h; path = src/imgui4xp.h; sourceTree = "<group>"; };
+		256CA1C6248C47BB009F4AAE /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
 		25804FC424883497008961CB /* IconsFontAwesome5.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = IconsFontAwesome5.h; path = src/IconsFontAwesome5.h; sourceTree = "<group>"; };
 		25804FC624886A62008961CB /* fa-solid-900.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.pascal; name = "fa-solid-900.inc"; path = "src/fa-solid-900.inc"; sourceTree = "<group>"; };
 		25804FC824886B2B008961CB /* ImgFontAtlas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImgFontAtlas.h; sourceTree = "<group>"; };
@@ -60,6 +62,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D6A7BDAA16A1DEA200D1426A /* OpenGL.framework in Frameworks */,
+				256CA1C7248C47BB009F4AAE /* ApplicationServices.framework in Frameworks */,
 				D6A7BDC116A1DEC000D1426A /* CoreFoundation.framework in Frameworks */,
 				25253B35247F9FD10061BFC2 /* XPLM.framework in Frameworks */,
 			);
@@ -155,6 +158,7 @@
 		D6A7BDAD16A1DEA700D1426A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				256CA1C6248C47BB009F4AAE /* ApplicationServices.framework */,
 				25253B34247F9FD10061BFC2 /* XPLM.framework */,
 				D6A7BDC016A1DEC000D1426A /* CoreFoundation.framework */,
 				D6A7BDA916A1DEA200D1426A /* OpenGL.framework */,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,11 +81,8 @@ find_library(GLUT_LIBRARY NAMES glut GLUT glut64)  # apt install freeglut3-dev
 
 # Link X-Plane plugin system libraries. They are only provided for OS X and Windows.
 if (WIN32 OR APPLE)
-# if (WIN32)
     find_library(XPLM_LIBRARY NAMES XPLM XPLM_64.lib)
     target_link_libraries(imgui4xp ${XPLM_LIBRARY})
-#    find_library(XPWIDGETS_LIBRARY NAMES XPWidgets XPWidgets_64.lib)
-#    target_link_libraries(imgui4xp ${XPLM_LIBRARY} ${XPWIDGETS_LIBRARY})
 endif ()
 
 # Link library for dynamic loading of shared objects on UNIX systems.
@@ -96,15 +93,10 @@ endif ()
 
 # Link OS X core system libraries.
 if (APPLE)
-    find_library(IOKIT_LIBRARY IOKit)
+    find_library(APPLICATION_SERVICES ApplicationServices)
     find_library(CORE_FOUNDATION_LIBRARY CoreFoundation)
-    find_library(GLUT_LIBRARY GLUT)
     find_library(OpenGL_LIBRARY OpenGL)
-    find_library(Cocoa_LIBRARY Cocoa)
-
-    target_link_libraries(imgui4xp ${IOKIT_LIBRARY} ${CORE_FOUNDATION_LIBRARY} ${GLUT_LIBRARY})
-    target_link_libraries(imgui4xp ${OpenGL_LIBRARY} ${Cocoa_LIBRARY})
-
+    target_link_libraries(imgui4xp ${APPLICATION_SERVICES} ${CORE_FOUNDATION_LIBRARY} ${OpenGL_LIBRARY})
 endif ()
 
 if (WIN32)
@@ -123,7 +115,7 @@ elseif (APPLE)
     # conflict with other plugins, in particular ones with Lua interpreter
     # embedded.
     target_link_libraries(imgui4xp "-exported_symbols_list ${CMAKE_SOURCE_DIR}/imgui4xp.sym_mac")
-    target_link_libraries(imgui4xp "-framework XPLM -framework XPWidgets -ldl")
+    target_link_libraries(imgui4xp "-ldl")
 elseif (UNIX)
     # Specify additional runtime search laths for dynamically-linked libraries.
     # Restrict set of symbols exported from the plugin. This reduces changes of

--- a/src/ImgWindow/ImgWindow.cpp
+++ b/src/ImgWindow/ImgWindow.cpp
@@ -82,8 +82,10 @@ ImgWindow::ImgWindow(
 		first_init=true;
 	}
 
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 	// we render ourselves, we don't use the DrawListsFunc
 	io.RenderDrawListsFn = nullptr;
+#endif
 	// set up the Keymap
 	io.KeyMap[ImGuiKey_Tab] = XPLM_VK_TAB;
 	io.KeyMap[ImGuiKey_LeftArrow] = XPLM_VK_LEFT;

--- a/src/ImgWindow/ImgWindow.h
+++ b/src/ImgWindow/ImgWindow.h
@@ -37,6 +37,7 @@
 
 #include "SystemGL.h"
 
+#include <climits>
 #include <string>
 #include <memory>
 

--- a/src/fa-solid-900.inc
+++ b/src/fa-solid-900.inc
@@ -1,5 +1,18 @@
 // File: 'fa-solid-900.ttf' (202616 bytes)
 // Exported using binary_to_compressed_c.cpp
+
+// The source font was downloaded from
+// https://github.com/FortAwesome/Font-Awesome/blob/master/webfonts/fa-solid-900.ttf
+// Please read here more about Font Awesome's icons:
+// https://fontawesome.com/icons?d=gallery&m=free
+// See here for the license conditions:
+// https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt
+
+// The below array represents the entire .ttf file.
+// The array has been generated using binary_to_compressed_c.cpp
+// that comes with ImGui:
+// https://github.com/ocornut/imgui/blob/tables/misc/fonts/binary_to_compressed_c.cpp
+
 static const unsigned int fa_solid_900_compressed_size = 143424;
 static const unsigned int fa_solid_900_compressed_data[143424/4] =
 {

--- a/src/imgui/imconfig.h
+++ b/src/imgui/imconfig.h
@@ -13,6 +13,11 @@
 
 #pragma once
 
+//--- In cross compilations TARGET_OS_OSX might not be correctly defined
+#if defined(__APPLE__) && !defined(TARGET_OS_OSX)
+#define TARGET_OS_OSX 1
+#endif
+
 //---- Define assertion handler. Defaults to calling assert().
 // If your macro uses multiple statements, make sure is enclosed in a 'do { .. } while (0)' block so it can be used as a single statement.
 //#define IM_ASSERT(_EXPR)  MyAssert(_EXPR)
@@ -24,7 +29,7 @@
 //#define IMGUI_API __declspec( dllimport )
 
 //---- Don't define obsolete functions/enums/behaviors. Consider enabling from time to time after updating to avoid using soon-to-be obsolete function/names.
-//#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
+#define IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 
 //---- Disable all of Dear ImGui or don't implement standard windows.
 // It is very strongly recommended to NOT disable the demo windows during development. Please read comments in imgui_demo.cpp.
@@ -36,7 +41,7 @@
 //#define IMGUI_DISABLE_WIN32_DEFAULT_CLIPBOARD_FUNCTIONS   // [Win32] Don't implement default clipboard handler. Won't use and link with OpenClipboard/GetClipboardData/CloseClipboard etc.
 //#define IMGUI_DISABLE_WIN32_DEFAULT_IME_FUNCTIONS         // [Win32] Don't implement default IME handler. Won't use and link with ImmGetContext/ImmSetCompositionWindow.
 //#define IMGUI_DISABLE_WIN32_FUNCTIONS                     // [Win32] Won't use and link with any Win32 function (clipboard, ime).
-//#define IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS      // [OSX] Implement default OSX clipboard handler (need to link with '-framework ApplicationServices', this is why this is not the default).
+#define IMGUI_ENABLE_OSX_DEFAULT_CLIPBOARD_FUNCTIONS      // [OSX] Implement default OSX clipboard handler (need to link with '-framework ApplicationServices', this is why this is not the default).
 //#define IMGUI_DISABLE_DEFAULT_FORMAT_FUNCTIONS            // Don't implement ImFormatString/ImFormatStringV so you can implement them yourself (e.g. if you don't want to link with vsnprintf)
 //#define IMGUI_DISABLE_DEFAULT_MATH_FUNCTIONS              // Don't implement ImFabs/ImSqrt/ImPow/ImFmod/ImCos/ImSin/ImAcos/ImAtan2 so you can implement them yourself.
 //#define IMGUI_DISABLE_DEFAULT_FILE_FUNCTIONS              // Don't implement ImFileOpen/ImFileClose/ImFileRead/ImFileWrite so you can implement them yourself if you don't want to link with fopen/fclose/fread/fwrite. This will also disable the LogToTTY() function.

--- a/src/imgui_starter_window.cpp
+++ b/src/imgui_starter_window.cpp
@@ -587,7 +587,7 @@ void ImguiWidget::buildInterface() {
         ImGui::TreePop();
     }
 
-    if (ImGui::TreeNodeEx("Misc", ImGuiTreeNodeFlags_Selected)) {
+    if (ImGui::TreeNodeEx("Misc")) {
         // Create a bullet style enumeration
         ImGui::Bullet(); ImGui::TextUnformatted("Bullet");
         ImGui::Bullet(); ImGui::TextUnformatted("Style");


### PR DESCRIPTION
Hi Bill,

copy&paste didn't work properly on Macs (didn't copy/paste from outside X-Plane) as
1. already during build a Mac build wasn't properly identified,
2. if identified another library `ApplicationServices` needs to be added.

While adding to `CMakeLists.txt` I took the liberty to remove unneded stuff.

- Birger