### PR TITLE
add missing glBindTexture to ImgWindow::RenderImGui

### DIFF
--- a/src/ImgWindow/ImgWindow.cpp
+++ b/src/ImgWindow/ImgWindow.cpp
@@ -318,6 +318,7 @@ ImgWindow::RenderImGui(ImDrawData *draw_data)
 	glDisableClientState(GL_VERTEX_ARRAY);
 	glDisableClientState(GL_COLOR_ARRAY);
 	glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+	glBindTexture(GL_TEXTURE_2D, 0);
 	glPopAttrib();
 	glPopClientAttrib();
 }


### PR DESCRIPTION
missing glBindTexture(GL_TEXTURE_2D, 0); causes RenderImGui to fail to display.
taken from:
https://github.com/X-Plane/XLua/blob/0d98b72a0a2bbe9749767c572f32b48f8a97bbbe/src/FloatingWindows/ImGUIIntegration.cpp#L201